### PR TITLE
Add missing PTDS entry to setup.py

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -105,6 +105,7 @@ extensions = cythonize(
             ],
             libraries=["cuda", "rmm"],
             language="c++",
+            define_macros=define_macros,
             extra_compile_args=["-std=c++14"],
         )
     ],


### PR DESCRIPTION
This entry was missing, causing the previous commit to be insufficient for "implicit" PTDS.